### PR TITLE
Fix: Display "No awards found" in Extras window

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -489,26 +489,41 @@ class Extras(BaseDialog):
 		awards_id = 2064
 		if not awards_id in self.enabled_lists: return
 		try:
+			item_list = []
 			awards_string = self.meta_get('extra_ratings', {}).get('Awards', '')
-			if not awards_string or awards_string == "N/A":
-				self.setProperty('awards.number', 'x0')
-				return
-			awards_list = [i.strip() for i in awards_string.split('. ') if i.strip()]
-			if not awards_list:
-				self.setProperty('awards.number', 'x0')
-				return
-			def builder():
-				for item in awards_list:
-					try:
-						listitem = self.make_listitem()
-						listitem.setProperty('name', item)
-						yield listitem
-					except: pass
-			item_list = list(builder())
-			self.setProperty('awards.number', count_insert % len(item_list))
+			if awards_string and awards_string != "N/A":
+				awards_list_processed = [i.strip() for i in awards_string.split('. ') if i.strip()]
+				if awards_list_processed:
+					def builder():
+						for item in awards_list_processed:
+							try:
+								listitem = self.make_listitem()
+								listitem.setProperty('name', item)
+								yield listitem
+							except: pass
+					item_list = list(builder())
+
+			if not item_list:
+				listitem = self.make_listitem()
+				listitem.setProperty('name', "No awards found")
+				item_list.append(listitem)
+				self.setProperty('awards.number', 'x1') # Display x1 for "No awards found"
+			else:
+				self.setProperty('awards.number', count_insert % len(item_list))
+
 			self.add_items(awards_id, item_list)
 		except:
-			self.setProperty('awards.number', 'x0')
+			# In case of any exception, try to display "No awards found"
+			# This is a fallback, ideally specific exceptions should be handled if possible
+			try:
+				item_list = []
+				listitem = self.make_listitem()
+				listitem.setProperty('name', "No awards found")
+				item_list.append(listitem)
+				self.setProperty('awards.number', 'x1')
+				self.add_items(awards_id, item_list)
+			except:
+				self.setProperty('awards.number', 'x0') # Final fallback if creating listitem fails
 
 	def make_collection(self):
 		if self.media_type != 'movie': return


### PR DESCRIPTION
This commit updates the Awards section in the Extras window to explicitly display "No awards found" when award information is not available from the API or is listed as "N/A".

This addresses your feedback that the awards section would not appear at all if no awards were found, making it difficult to debug.

Key changes:
- Modified the `make_awards` method in `extras.py` to create a "No awards found" list item if the awards string is empty, "N/A", or processing results in no actual awards.
- The visibility logic in `extras.xml` remains unchanged as it correctly handles showing the section when it contains the "No awards found" item.