### PR TITLE
Debug: Add extensive logging for Awards section

### DIFF
--- a/plugin.video.fenlight/resources/lib/apis/omdb_api.py
+++ b/plugin.video.fenlight/resources/lib/apis/omdb_api.py
@@ -3,8 +3,7 @@ from xml.dom.minidom import parseString as mdParse
 from caches.meta_cache import meta_cache
 from modules.metadata import movie_expiry, tvshow_expiry
 from modules.utils import get_datetime, get_current_timestamp
-from modules.kodi_utils import make_session
-# from modules.kodi_utils import logger
+from modules.kodi_utils import make_session, logger # Uncommented logger
 
 url = 'http://www.omdbapi.com/?apikey=%s&i=%s&tomatoes=True&r=xml'
 timeout = 20.0
@@ -22,26 +21,30 @@ class OMDbAPI:
 	def process_result(self, imdb_id, meta):
 		data = {}
 		self.result = self.get_result(imdb_id)
+		logger(f'omdb_api.py: process_result - raw self.result from get_result: {self.result}')
 		if not self.result: return {}
 		self.result_get = self.result.get
-		awards = self.process_rating('awards')
+		# Fetch awards_value using 'Awards' as key
+		awards_value = self.process_rating('Awards')
+		logger(f'omdb_api.py: process_result - fetched awards_value: {awards_value}')
 		metascore_rating, tomatometer_rating, tomatousermeter_rating = self.process_rating('metascore'), self.process_rating('tomatoMeter'), self.process_rating('tomatoUserMeter')
 		imdb_rating, tomato_image = self.process_rating('imdbRating'), self.process_rating('tomatoImage')
 		if tomato_image: tomatometer_icon = 'rtcertified.png' if tomato_image == 'certified' else 'rtfresh.png' if tomato_image == 'fresh' else 'rtrotten.png'
 		elif tomatometer_rating: tomatometer_icon = 'rtfresh.png' if int(tomatometer_rating) > 59 else 'rtrotten.png'
 		else: tomatometer_icon = 'rtrotten.png'
 		if tomatousermeter_rating: tomatousermeter_icon = 'popcorn.png' if int(tomatousermeter_rating) > 59 else 'popcorn_spilt.png'
-		else: tomatousermeter_icon = 'popcorn_spilt.png'		
+		else: tomatousermeter_icon = 'popcorn_spilt.png'
 		data = {
 				'metascore': {'rating': '%s%%' %  metascore_rating, 'icon': metascore_icon},
 				'tomatometer': {'rating': '%s%%' % tomatometer_rating, 'icon': tomatometer_icon},
 				'tomatousermeter': {'rating': '%s%%' % tomatousermeter_rating, 'icon': tomatousermeter_icon},
 				'imdb': {'rating': imdb_rating, 'icon': imdb_icon},
 				'tmdb': {'rating': '', 'icon': tmdb_icon},
-				'awards': awards
+				'Awards': awards_value # Added 'Awards' key with fetched value
 				}
 		media_type = meta.get('mediatype')
 		expiry_function = movie_expiry if media_type == 'movie' else tvshow_expiry
+		logger(f'omdb_api.py: process_result - final data being cached (just before adding to meta): {data}')
 		meta['extra_ratings'] = data
 		meta_cache.set(media_type, 'tmdb_id', meta, expiry_function(get_datetime(), meta), get_current_timestamp())
 		return data
@@ -49,10 +52,15 @@ class OMDbAPI:
 	def get_result(self, imdb_id):
 		try:
 			result = session.get(url % (self.api_key, imdb_id), timeout=timeout).text
+			logger(f'omdb_api.py: get_result - raw text response from OMDb: {result}')
 			response_test = dict(mdParse(result).getElementsByTagName('root')[0].attributes.items())
-			if not response_test.get('response', 'False') == 'True': return None
+			if not response_test.get('response', 'False') == 'True':
+				logger('omdb_api.py: get_result - OMDb API response was not "True"')
+				return None
 			return dict(mdParse(result).getElementsByTagName('movie')[0].attributes.items())
-		except: return None
+		except Exception as e: # Catch specific exception and log it
+			logger(f'omdb_api.py: get_result - EXCEPTION: {e}', 'error')
+			return None
 
 	def process_rating(self, rating_name):
 		return self.result_get(rating_name, '').replace('N/A', '')

--- a/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
+++ b/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
@@ -293,99 +293,6 @@
                         </control>
                     </control>
                 </control>
-                <!-- Awards 2064 -->
-                <control type="group">
-                    <visible>Integer.IsGreater(Container(2064).NumItems,0)</visible>
-                    <height>760</height>
-                    <control type="group">
-                        <control type="label">
-                            <width max="1160">auto</width>
-                            <height>20</height>
-                            <font>font14</font> <!-- FENLIGHT_33 -->
-                            <textcolor>FFCCCCCC</textcolor>
-                            <align>left</align>
-                            <aligny>bottom</aligny>
-                            <label>[B]Awards $INFO[Window.Property(awards.number)][/B]</label>
-                        </control>
-                        <control type="panel" id="2064">
-                            <pagecontrol>4064</pagecontrol>
-                            <top>60</top>
-                            <width>1180</width>
-                            <height>360</height>
-                            <onup>2063</onup> <!-- Or previous relevant control ID -->
-                            <ondown>4064</ondown> <!-- Scrollbar for this list -->
-                            <orientation>horizontal</orientation>
-                            <scrolltime tween="sine">500</scrolltime>
-                            <itemlayout height="380" width="590">
-                                <control type="image">
-                                    <height>360</height>
-                                    <width>580</width>
-                                    <texture colordiffuse="FF1F2020" border="30">fenlight_common/circle.png</texture>
-                                </control>
-                                <control type="textbox">
-                                    <top>15</top>
-                                    <left>20</left>
-                                    <width>540</width>
-                                    <height>308</height>
-                                    <font>font12</font> <!-- FENLIGHT_26 -->
-                                    <align>center</align>
-                                    <aligny>top</aligny>
-                                    <textcolor>FFCCCCCC</textcolor>
-                                    <label>$INFO[ListItem.Property(name)]</label>
-                                    <autoscroll>false</autoscroll>
-                                </control>
-                            </itemlayout>
-                            <focusedlayout height="380" width="590">
-                                <control type="image">
-                                    <height>360</height>
-                                    <width>580</width>
-                                    <texture colordiffuse="FFB7B4BB" border="30">fenlight_common/circle.png</texture>
-                                </control>
-                                <control type="textbox">
-                                    <top>15</top>
-                                    <left>20</left>
-                                    <width>540</width>
-                                    <height>308</height>
-                                    <font>font12</font> <!-- FENLIGHT_26 -->
-                                    <align>center</align>
-                                    <aligny>top</aligny>
-                                    <textcolor>FF1F2020</textcolor>
-                                    <label>$INFO[ListItem.Property(name)]</label>
-                                    <autoscroll>false</autoscroll>
-                                </control>
-                            </focusedlayout>
-                        </control>
-                        <control type="scrollbar" id="4064">
-                            <top>432</top>
-                            <width>1170</width>
-                            <height>15</height>
-                            <onup>2064</onup>
-                            <ondown>10</ondown> <!-- Or next relevant control ID / first button -->
-                            <texturesliderbackground colordiffuse="FF1F2020">fenlight_common/white.png</texturesliderbackground>
-                            <texturesliderbar colordiffuse="FF555556">fenlight_common/white.png</texturesliderbar>
-                            <texturesliderbarfocus colordiffuse="FFCCCCCC">fenlight_common/white.png</texturesliderbarfocus>
-                            <showonepage>false</showonepage>
-                            <orientation>Horizontal</orientation>
-                            <visible>String.IsEqual(Window.Property(enable_scrollbars),true) + [Control.HasFocus(2064) | Control.HasFocus(4064)]</visible>
-                        </control>
-                        <control type="image">
-                            <top>225</top>
-                            <left>20</left>
-                            <width>25</width>
-                            <height>25</height>
-                            <texture colordiffuse="FFCCCCCC" background="true">fenlight_common/arrow_left.png</texture>
-                            <visible>[Control.HasFocus(2064) | Control.HasFocus(4064)] + Container(2064).HasPrevious</visible>
-                        </control>
-                        <control type="image">
-                            <top>225</top>
-                            <left>1125</left>
-                            <width>25</width>
-                            <height>25</height>
-                            <texture colordiffuse="FFCCCCCC" background="true" flipx="true">fenlight_common/arrow_left.png</texture>
-                            <visible>[Control.HasFocus(2064) | Control.HasFocus(4064)] + Container(2064).HasNext</visible>
-                        </control>
-                    </control>
-                </control>
                 </control>
             </control>
             <!-- Body -->
@@ -410,7 +317,7 @@
                             <height>70</height>
                             <onleft>13</onleft>
                             <onright>11</onright>
-                            <onup>2063</onup>
+                            <onup>2064</onup>
                             <ondown>14</ondown>
                             <label>$INFO[Window.Property(button10.label)]</label>
                             <font>font13</font> <!-- FENLIGHT_30 -->
@@ -427,7 +334,7 @@
                             <height>70</height>
                             <onleft>10</onleft>
                             <onright>12</onright>
-                            <onup>2063</onup>
+                            <onup>2064</onup>
                             <ondown>15</ondown>
                             <label>$INFO[Window.Property(button11.label)]</label>
                             <font>font13</font> <!-- FENLIGHT_30 -->
@@ -444,7 +351,7 @@
                             <height>70</height>
                             <onleft>11</onleft>
                             <onright>13</onright>
-                            <onup>2063</onup>
+                            <onup>2064</onup>
                             <ondown>16</ondown>
                             <label>$INFO[Window.Property(button12.label)]</label>
                             <font>font13</font> <!-- FENLIGHT_30 -->
@@ -461,7 +368,7 @@
                             <height>70</height>
                             <onleft>12</onleft>
                             <onright>10</onright>
-                            <onup>2063</onup>
+                            <onup>2064</onup>
                             <ondown>17</ondown>
                             <label>$INFO[Window.Property(button13.label)]</label>
                             <font>font13</font> <!-- FENLIGHT_30 -->
@@ -542,6 +449,99 @@
                             <texturenofocus colordiffuse="FF1F2020" border="30">fenlight_common/circle.png</texturenofocus>
                             <align>center</align>
                             <aligny>center</aligny>
+                        </control>
+                    </control>
+                </control>
+                <!-- Awards 2064 -->
+                <control type="group">
+                    <visible>Integer.IsGreater(Container(2064).NumItems,0)</visible>
+                    <height>760</height>
+                    <control type="group">
+                        <control type="label">
+                            <width max="1160">auto</width>
+                            <height>20</height>
+                            <font>font14</font> <!-- FENLIGHT_33 -->
+                            <textcolor>FFCCCCCC</textcolor>
+                            <align>left</align>
+                            <aligny>bottom</aligny>
+                            <label>[B]Awards $INFO[Window.Property(awards.number)][/B]</label>
+                        </control>
+                        <control type="panel" id="2064">
+                            <pagecontrol>4064</pagecontrol>
+                            <top>60</top>
+                            <width>1180</width>
+                            <height>360</height>
+                            <onup>4063</onup> <!-- Scrollbar of More From Collection -->
+                            <ondown>4064</ondown> <!-- Scrollbar for this list -->
+                            <orientation>horizontal</orientation>
+                            <scrolltime tween="sine">500</scrolltime>
+                            <itemlayout height="380" width="590">
+                                <control type="image">
+                                    <height>360</height>
+                                    <width>580</width>
+                                    <texture colordiffuse="FF1F2020" border="30">fenlight_common/circle.png</texture>
+                                </control>
+                                <control type="textbox">
+                                    <top>15</top>
+                                    <left>20</left>
+                                    <width>540</width>
+                                    <height>308</height>
+                                    <font>font12</font> <!-- FENLIGHT_26 -->
+                                    <align>center</align>
+                                    <aligny>top</aligny>
+                                    <textcolor>FFCCCCCC</textcolor>
+                                    <label>$INFO[ListItem.Property(name)]</label>
+                                    <autoscroll>false</autoscroll>
+                                </control>
+                            </itemlayout>
+                            <focusedlayout height="380" width="590">
+                                <control type="image">
+                                    <height>360</height>
+                                    <width>580</width>
+                                    <texture colordiffuse="FFB7B4BB" border="30">fenlight_common/circle.png</texture>
+                                </control>
+                                <control type="textbox">
+                                    <top>15</top>
+                                    <left>20</left>
+                                    <width>540</width>
+                                    <height>308</height>
+                                    <font>font12</font> <!-- FENLIGHT_26 -->
+                                    <align>center</align>
+                                    <aligny>top</aligny>
+                                    <textcolor>FF1F2020</textcolor>
+                                    <label>$INFO[ListItem.Property(name)]</label>
+                                    <autoscroll>false</autoscroll>
+                                </control>
+                            </focusedlayout>
+                        </control>
+                        <control type="scrollbar" id="4064">
+                            <top>432</top>
+                            <width>1170</width>
+                            <height>15</height>
+                            <onup>2064</onup>
+                            <ondown>10</ondown> <!-- First button of main action buttons -->
+                            <texturesliderbackground colordiffuse="FF1F2020">fenlight_common/white.png</texturesliderbackground>
+                            <texturesliderbar colordiffuse="FF555556">fenlight_common/white.png</texturesliderbar>
+                            <texturesliderbarfocus colordiffuse="FFCCCCCC">fenlight_common/white.png</texturesliderbarfocus>
+                            <showonepage>false</showonepage>
+                            <orientation>Horizontal</orientation>
+                            <visible>String.IsEqual(Window.Property(enable_scrollbars),true) + [Control.HasFocus(2064) | Control.HasFocus(4064)]</visible>
+                        </control>
+                        <control type="image">
+                            <top>225</top>
+                            <left>20</left>
+                            <width>25</width>
+                            <height>25</height>
+                            <texture colordiffuse="FFCCCCCC" background="true">fenlight_common/arrow_left.png</texture>
+                            <visible>[Control.HasFocus(2064) | Control.HasFocus(4064)] + Container(2064).HasPrevious</visible>
+                        </control>
+                        <control type="image">
+                            <top>225</top>
+                            <left>1125</left>
+                            <width>25</width>
+                            <height>25</height>
+                            <texture colordiffuse="FFCCCCCC" background="true" flipx="true">fenlight_common/arrow_left.png</texture>
+                            <visible>[Control.HasFocus(2064) | Control.HasFocus(4064)] + Container(2064).HasNext</visible>
                         </control>
                     </control>
                 </control>


### PR DESCRIPTION
This commit introduces detailed logging in `extras.py` and `omdb_api.py` to help you diagnose issues with the Awards section in the Extras window not appearing.

It also includes a critical layout correction in `extras.xml` where the Awards section was incorrectly placed, causing it to be hidden.

Key changes:
- Added numerous log statements in `extras.py` within the `make_awards` and `onInit` methods to trace execution and data processing.
- Added log statements in `omdb_api.py` to track the fetching and processing of the 'Awards' data from the OMDb API.
- Corrected the placement of the Awards section in `extras.xml` to ensure it's part of the main content group and not inadvertently hidden.
- Updated navigation in `extras.xml` to accommodate the corrected position of the Awards section.