### PR TITLE
Fix: Correct key casing for 'awards' in omdb_api.py

### DIFF
--- a/plugin.video.fenlight/resources/lib/apis/omdb_api.py
+++ b/plugin.video.fenlight/resources/lib/apis/omdb_api.py
@@ -24,8 +24,8 @@ class OMDbAPI:
 		logger("omdb_api.py", f'process_result - raw self.result from get_result: {self.result}')
 		if not self.result: return {}
 		self.result_get = self.result.get
-		# Fetch awards_value using 'Awards' as key
-		awards_value = self.process_rating('Awards')
+		# Fetch awards_value using 'awards' (lowercase) as key for process_rating, as self.result uses lowercase.
+		awards_value = self.process_rating('awards')
 		logger("omdb_api.py", f'process_result - fetched awards_value: {awards_value}')
 		metascore_rating, tomatometer_rating, tomatousermeter_rating = self.process_rating('metascore'), self.process_rating('tomatoMeter'), self.process_rating('tomatoUserMeter')
 		imdb_rating, tomato_image = self.process_rating('imdbRating'), self.process_rating('tomatoImage')


### PR DESCRIPTION
This commit fixes a bug in `omdb_api.py` where the awards string was not being correctly retrieved from the parsed OMDb API response due to a key case mismatch.

The OMDb API returns the awards information under the key 'awards' (lowercase), but the code was attempting to read it using 'Awards' (uppercase). This resulted in an empty awards value being processed and cached.

The `process_result` method in `OMDbAPI` now correctly uses `self.process_rating('awards')` (lowercase) to fetch the value, and then stores it under the key 'Awards' (uppercase) in the internal data structure for consistency with `extras.py`.

Existing logging should now show the correct awards string being fetched.