### PR TITLE
Feat: Display awards in plot & comment out separate section

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -204,7 +204,15 @@ class Extras(BaseDialog):
 
 	def make_plot_and_tagline(self):
 		self.plot = self.meta_get('tvshow_plot', '') or self.meta_get('plot', '') or ''
-		if not self.plot: return
+		logger("extras.py", f"make_plot_and_tagline - Initial plot: {self.plot}")
+		awards_string = self.meta_get('extra_ratings', {}).get('Awards', '')
+		logger("extras.py", f"make_plot_and_tagline - Fetched awards_string: {awards_string}")
+		if awards_string and awards_string != 'N/A':
+			self.plot = f"[B]Awards:[/B] {awards_string}[CR][CR]{self.plot}"
+			logger("extras.py", f"make_plot_and_tagline - Plot after prepending awards: {self.plot}")
+		else:
+			logger("extras.py", "make_plot_and_tagline - No awards string to prepend or it was N/A")
+		if not self.plot: return # Check if plot became empty after potential modifications, though unlikely here.
 		self.tagline = self.meta_get('tagline') or ''
 		if self.tagline: self.plot = '[I]%s[/I][CR][CR]%s' % (self.tagline, self.plot)
 		if plot_id in self.enabled_lists: self.setProperty('plot_enabled', 'true')

--- a/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
+++ b/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
@@ -317,7 +317,7 @@
                             <height>70</height>
                             <onleft>13</onleft>
                             <onright>11</onright>
-                            <onup>2064</onup>
+                            <onup>4063</onup>
                             <ondown>14</ondown>
                             <label>$INFO[Window.Property(button10.label)]</label>
                             <font>font13</font> <!-- FENLIGHT_30 -->
@@ -334,7 +334,7 @@
                             <height>70</height>
                             <onleft>10</onleft>
                             <onright>12</onright>
-                            <onup>2064</onup>
+                            <onup>4063</onup>
                             <ondown>15</ondown>
                             <label>$INFO[Window.Property(button11.label)]</label>
                             <font>font13</font> <!-- FENLIGHT_30 -->
@@ -351,7 +351,7 @@
                             <height>70</height>
                             <onleft>11</onleft>
                             <onright>13</onright>
-                            <onup>2064</onup>
+                            <onup>4063</onup>
                             <ondown>16</ondown>
                             <label>$INFO[Window.Property(button12.label)]</label>
                             <font>font13</font> <!-- FENLIGHT_30 -->
@@ -368,7 +368,7 @@
                             <height>70</height>
                             <onleft>12</onleft>
                             <onright>10</onright>
-                            <onup>2064</onup>
+                            <onup>4063</onup>
                             <ondown>17</ondown>
                             <label>$INFO[Window.Property(button13.label)]</label>
                             <font>font13</font> <!-- FENLIGHT_30 -->
@@ -452,7 +452,7 @@
                         </control>
                     </control>
                 </control>
-                <!-- Awards 2064 -->
+                <!-- Awards 2064 START COMMENTED OUT
                 <control type="group">
                     <visible>Integer.IsGreater(Container(2064).NumItems,0)</visible>
                     <height>760</height>
@@ -460,7 +460,7 @@
                         <control type="label">
                             <width max="1160">auto</width>
                             <height>20</height>
-                            <font>font14</font> <!-- FENLIGHT_33 -->
+                            <font>font14</font>
                             <textcolor>FFCCCCCC</textcolor>
                             <align>left</align>
                             <aligny>bottom</aligny>
@@ -471,8 +471,8 @@
                             <top>60</top>
                             <width>1180</width>
                             <height>360</height>
-                            <onup>4063</onup> <!-- Scrollbar of More From Collection -->
-                            <ondown>4064</ondown> <!-- Scrollbar for this list -->
+                            <onup>4063</onup>
+                            <ondown>4064</ondown>
                             <orientation>horizontal</orientation>
                             <scrolltime tween="sine">500</scrolltime>
                             <itemlayout height="380" width="590">
@@ -486,7 +486,7 @@
                                     <left>20</left>
                                     <width>540</width>
                                     <height>308</height>
-                                    <font>font12</font> <!-- FENLIGHT_26 -->
+                                    <font>font12</font>
                                     <align>center</align>
                                     <aligny>top</aligny>
                                     <textcolor>FFCCCCCC</textcolor>
@@ -505,7 +505,7 @@
                                     <left>20</left>
                                     <width>540</width>
                                     <height>308</height>
-                                    <font>font12</font> <!-- FENLIGHT_26 -->
+                                    <font>font12</font>
                                     <align>center</align>
                                     <aligny>top</aligny>
                                     <textcolor>FF1F2020</textcolor>
@@ -519,7 +519,7 @@
                             <width>1170</width>
                             <height>15</height>
                             <onup>2064</onup>
-                            <ondown>10</ondown> <!-- First button of main action buttons -->
+                            <ondown>10</ondown>
                             <texturesliderbackground colordiffuse="FF1F2020">fenlight_common/white.png</texturesliderbackground>
                             <texturesliderbar colordiffuse="FF555556">fenlight_common/white.png</texturesliderbar>
                             <texturesliderbarfocus colordiffuse="FFCCCCCC">fenlight_common/white.png</texturesliderbarfocus>
@@ -545,6 +545,7 @@
                         </control>
                     </control>
                 </control>
+                Awards 2064 END COMMENTED OUT -->
                 <!-- Plot 2000 -->
                 <control type="group">
                     <visible>String.IsEqual(Window.Property(plot_enabled),true)</visible>
@@ -2021,8 +2022,8 @@
                             <top>432</top>
                             <width>1170</width>
                             <height>15</height>
-                            <onup>2063</onup> <!-- This was the original ondown for 4063 -->
-                            <ondown>2064</ondown> <!-- Changed to navigate to the new Awards section -->
+                            <onup>2063</onup>
+                            <ondown>10</ondown> <!-- Reverted to original target -->
                             <texturesliderbackground colordiffuse="FF1F2020">fenlight_common/white.png</texturesliderbackground>
                             <texturesliderbar colordiffuse="FF555556">fenlight_common/white.png</texturesliderbar>
                             <texturesliderbarfocus colordiffuse="FFCCCCCC">fenlight_common/white.png</texturesliderbarfocus>


### PR DESCRIPTION
This commit implements an alternative approach to displaying awards by prepending the awards string to the movie/show plot in the Extras window. This is an attempt to work around issues encountered with displaying awards in a separate list control.

Key changes:
- Modified `make_plot_and_tagline` in `extras.py` to fetch the 'Awards' string from metadata and prepend it to the plot if available. Added logging for this process.
- Commented out the previously added separate 'Awards' section (ID 2064) in `extras.xml` to avoid conflicts during testing.
- Reverted navigation changes in `extras.xml` that were associated with the commented-out Awards section.

The existing `make_awards` method and detailed logging in it, as well as in `omdb_api.py`, are retained from the
`debug/awards-section-logging` branch to aid further debugging if needed.