### PR TITLE
Fix: Ensure awards are loaded before display in extras plot

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -190,7 +190,7 @@ class Extras(BaseDialog):
 			else: return
 
 	def make_ratings(self, win_prop=4000):
-		data = self.get_omdb_ratings()
+		data = self.meta_get('extra_ratings', None)
 		if not data: return
 		active_extra_ratings = False
 		if self.rating: data['tmdb']['rating'] = self.rating
@@ -850,6 +850,7 @@ class Extras(BaseDialog):
 		self.mpaa, self.genre, self.network = self.meta_get('mpaa'), self.meta_get('genre'), self.meta_get('studio') or ''
 		self.status, self.duration_data = self.extra_info_get('status', '').replace(' Series', ''), int(float(self.meta_get('duration'))/60)
 		self.status_infoline_value = self.make_status_infoline()
+		self.meta['extra_ratings'] = self.get_omdb_ratings()
 		self.make_plot_and_tagline()
 
 	def set_properties(self):


### PR DESCRIPTION
I resolved a race condition in the Extras window where the plot and tagline were generated before the OMDb rating information (including awards) was fetched.

- I modified `set_starting_constants` in `extras.py` to call `get_omdb_ratings()` and store the result in `self.meta['extra_ratings']` *before* `make_plot_and_tagline()` is called.
- I adjusted `make_ratings()` to use the pre-fetched `extra_ratings` from `self.meta`, avoiding a redundant API call.

This ensures the awards summary from OMDb is consistently available and displayed in the extras plot.

I investigated alternative APIs for more detailed award information. I concluded that existing internal APIs do not readily provide more detail than the OMDB summary. A more detailed award display would require significant enhancements to IMDb scraping or integration of a new third-party API.