### PR TITLE
Refactor: Improve display of awards in extras window

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -40,7 +40,7 @@ setting_base, label_base, ratings_icon_base = 'fenlight.extras.%s.button', 'butt
 separator = '[B]  •  [/B]'
 button_ids = (10, 11, 12, 13, 14, 15, 16, 17, 50)
 plot_id, cast_id, recommended_id, more_like_this_id, reviews_id, comments_id, trivia_id = 2000, 2050, 2051, 2052, 2053, 2054, 2055
-blunders_id, parentsguide_id, in_lists_id, videos_id, year_id, genres_id, networks_id, collection_id = 2056, 2057, 2058, 2059, 2060, 2061, 2062, 2063
+blunders_id, parentsguide_id, in_lists_id, videos_id, year_id, genres_id, networks_id, collection_id, awards_id = 2056, 2057, 2058, 2059, 2060, 2061, 2062, 2063, 2064 # Added awards_id
 items_list_ids = (recommended_id, more_like_this_id, year_id, genres_id, networks_id, collection_id)
 text_list_ids = (reviews_id, trivia_id, blunders_id, parentsguide_id, comments_id)
 open_folder_list_ids = (in_lists_id,)
@@ -61,9 +61,9 @@ class Extras(BaseDialog):
 		self.control_id = None
 		self.set_starting_constants(kwargs)
 		self.set_properties()
-		self.tasks = (self.set_artwork, self.set_infoline1, self.set_infoline2, self.make_ratings, self.make_cast, self.make_recommended,
-					self.make_more_like_this, self.make_reviews, self.make_comments, self.make_in_lists, self.make_trivia, self.make_blunders, self.make_parentsguide,
-					self.make_videos, self.make_year, self.make_genres, self.make_network, self.make_collection) # Removed self.make_awards
+		self.tasks = (self.set_artwork, self.set_infoline1, self.set_infoline2, self.make_awards, self.make_blunders, self.make_cast, self.make_collection,
+					self.make_comments, self.make_genres, self.make_in_lists, self.make_more_like_this, self.make_network, self.make_parentsguide,
+					self.make_ratings, self.make_recommended, self.make_reviews, self.make_trivia, self.make_videos, self.make_year)
 
 	def onInit(self):
 		self.set_home_property('window_loaded', 'true')
@@ -202,14 +202,34 @@ class Extras(BaseDialog):
 			active_extra_ratings = True
 		if win_prop == 4000 and self.getProperty('tmdb_rating') == 'true': self.set_infoline1(remove_rating=True)
 
+	def make_awards(self):
+		if not awards_id in self.enabled_lists: return
+		def builder():
+			for item in awards_list:
+				try:
+					listitem = self.make_listitem()
+					listitem.setProperty('name', item)
+					yield listitem
+				except: pass
+		try:
+			awards_string = self.meta_get('extra_ratings', {}).get('Awards', '')
+			if not awards_string or awards_string == 'N/A':
+				self.setProperty('awards.number', count_insert % 0)
+				self.add_items(awards_id, [])
+				return
+			awards_list = [award.strip() for award in awards_string.split(' | ')]
+			item_list = list(builder())
+			self.setProperty('awards.number', count_insert % len(item_list))
+			# self.item_action_dict[awards_id] = 'name' # Not needed if items are not actionable
+			self.add_items(awards_id, item_list)
+		except:
+			self.setProperty('awards.number', count_insert % 0) # Ensure property is set on error
+			self.add_items(awards_id, []) # Ensure list is cleared or empty on error
+
 	def make_plot_and_tagline(self):
 		self.plot = self.meta_get('tvshow_plot', '') or self.meta_get('plot', '') or ''
 		# logger("extras.py", f"make_plot_and_tagline - Initial plot: {self.plot}") # Removed
-		awards_string = self.meta_get('extra_ratings', {}).get('Awards', '')
 		# logger("extras.py", f"make_plot_and_tagline - Fetched awards_string: {awards_string}") # Removed
-		if awards_string and awards_string != 'N/A':
-			self.plot = f"[B]Awards:[/B] {awards_string}[CR][CR]{self.plot}"
-			# logger("extras.py", f"make_plot_and_tagline - Plot after prepending awards: {self.plot}") # Removed
 		# else: # Removed logger for this path too
 			# logger("extras.py", "make_plot_and_tagline - No awards string to prepend or it was N/A") # Removed
 		if not self.plot: return # Check if plot became empty after potential modifications, though unlikely here.

--- a/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
+++ b/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
@@ -471,7 +471,7 @@
                             <width>1180</width>
                             <height>390</height>
                             <onup>14</onup>
-                            <ondown>2050</ondown>
+                            <ondown>2064</ondown>
                             <texturefocus colordiffuse="FFCCCCCC" border="30">fenlight_common/circle.png</texturefocus>
                             <texturenofocus colordiffuse="FF1F2020" border="30">fenlight_common/circle.png</texturenofocus>
                         </control>
@@ -531,7 +531,7 @@
                             <top>60</top>
                             <width>1180</width>
                             <height>360</height>
-                            <onup>50</onup>
+                            <onup>4064</onup>
                             <ondown>4050</ondown>
                             <orientation>horizontal</orientation>
                             <scrolltime tween="sine">500</scrolltime>
@@ -1818,6 +1818,77 @@
                             <height>25</height>
                             <texture colordiffuse="FFCCCCCC" background="true" flipx="true">fenlight_common/arrow_left.png</texture>
                             <visible>[Control.HasFocus(2062) | Control.HasFocus(4062)] + Container(2062).HasNext</visible>
+                        </control>
+                    </control>
+                </control>
+                <!-- Awards 2064 -->
+                <control type="group">
+                    <visible>Integer.IsGreater(Container(2064).NumItems,0)</visible>
+                    <height>400</height> <!-- Adjusted height for a text list -->
+                    <control type="group">
+                        <control type="label">
+                            <width max="1160">auto</width>
+                            <height>20</height>
+                            <font>font14</font> <!-- FENLIGHT_33 -->
+                            <textcolor>FFCCCCCC</textcolor>
+                            <align>left</align>
+                            <aligny>bottom</aligny>
+                            <label>[B]Awards $INFO[Window.Property(awards.number)][/B]</label>
+                        </control>
+                        <control type="panel" id="2064"> <!-- Changed to panel -->
+                            <pagecontrol>4064</pagecontrol>
+                            <top>40</top> <!-- Space below title -->
+                            <width>1180</width>
+                            <height>300</height> <!-- Height of the panel area -->
+                            <onup>50</onup> <!-- Plot button -->
+                            <ondown>4064</ondown> <!-- Scrollbar -->
+                            <orientation>vertical</orientation> <!-- Vertical list of awards -->
+                            <scrolltime tween="sine">500</scrolltime>
+                            <itemlayout height="50" width="1180"> <!-- Height for each award item -->
+                                <control type="textbox">
+                                    <left>15</left>
+                                    <top>5</top>
+                                    <width>1150</width>
+                                    <height>40</height>
+                                    <font>font12</font> <!-- FENLIGHT_26 -->
+                                    <align>left</align>
+                                    <aligny>center</aligny>
+                                    <textcolor>FFCCCCCC</textcolor>
+                                    <label>$INFO[ListItem.Property(name)]</label>
+                                </control>
+                            </itemlayout>
+                            <focusedlayout height="50" width="1180">
+                                <control type="image"> <!-- Background for focused item -->
+                                    <width>1180</width>
+                                    <height>50</height>
+                                    <texture colordiffuse="FFCCCCCC" border="5">fenlight_common/circle.png</texture>
+                                </control>
+                                <control type="textbox">
+                                    <left>15</left>
+                                    <top>5</top>
+                                    <width>1150</width>
+                                    <height>40</height>
+                                    <font>font12</font> <!-- FENLIGHT_26 -->
+                                    <align>left</align>
+                                    <aligny>center</aligny>
+                                    <textcolor>FF1F2020</textcolor> <!-- Focused text color -->
+                                    <label>$INFO[ListItem.Property(name)]</label>
+                                </control>
+                            </focusedlayout>
+                        </control>
+                        <control type="scrollbar" id="4064">
+                            <left>1185</left> <!-- Position to the right of the panel -->
+                            <top>40</top> <!-- Align with panel top -->
+                            <width>15</width>
+                            <height>300</height> <!-- Match panel height -->
+                            <onup>2064</onup>
+                            <ondown>2050</ondown> <!-- Cast List -->
+                            <texturesliderbackground colordiffuse="FF1F2020">fenlight_common/white.png</texturesliderbackground>
+                            <texturesliderbar colordiffuse="FF555556">fenlight_common/white.png</texturesliderbar>
+                            <texturesliderbarfocus colordiffuse="FFCCCCCC">fenlight_common/white.png</texturesliderbarfocus>
+                            <showonepage>false</showonepage>
+                            <orientation>vertical</orientation> <!-- Vertical scrollbar -->
+                            <visible>String.IsEqual(Window.Property(enable_scrollbars),true) + [Control.HasFocus(2064) | Control.HasFocus(4064)]</visible>
                         </control>
                     </control>
                 </control>


### PR DESCRIPTION
This commit refactors how awards are displayed in the media extras window.

Previously, awards were prepended to the plot summary. This change introduces a dedicated "Awards" section.

Key changes:
- Modified `make_plot_and_tagline` to no longer include awards in the plot.
- Added a new function `make_awards` to fetch and prepare awards data for display.
- Updated `__init__` to include `make_awards` in the window's initialization tasks.
- Added a new list control (panel) to the `extras.xml` skin file to display awards in their own section.
- Updated navigation in `extras.xml` to include the new awards section.

The new "Awards" section will list each award and show a total count, providing a cleaner and more organized presentation of this information.