### PR TITLE
fix: Display full awards sentence in plot text

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -229,12 +229,17 @@ class Extras(BaseDialog):
 	def make_plot_and_tagline(self):
 		self.plot = self.meta_get('tvshow_plot', '') or self.meta_get('plot', '') or ''
 		# logger("extras.py", f"make_plot_and_tagline - Initial plot: {self.plot}") # Removed
+		self.tagline = self.meta_get('tagline') or ''
+		if self.tagline: self.plot = '[I]%s[/I][CR][CR]%s' % (self.tagline, self.plot)
+
+		awards_string = self.meta_get('extra_ratings', {}).get('Awards', '')
 		# logger("extras.py", f"make_plot_and_tagline - Fetched awards_string: {awards_string}") # Removed
+		if awards_string and awards_string != 'N/A' and awards_string.strip():
+			formatted_awards = '[CR][CR][B]Awards:[/B][CR]' + awards_string.strip()
+			self.plot += formatted_awards
 		# else: # Removed logger for this path too
 			# logger("extras.py", "make_plot_and_tagline - No awards string to prepend or it was N/A") # Removed
 		if not self.plot: return # Check if plot became empty after potential modifications, though unlikely here.
-		self.tagline = self.meta_get('tagline') or ''
-		if self.tagline: self.plot = '[I]%s[/I][CR][CR]%s' % (self.tagline, self.plot)
 		if plot_id in self.enabled_lists: self.setProperty('plot_enabled', 'true')
 
 	def make_cast(self):


### PR DESCRIPTION
Corrects the handling of the 'Awards' metadata string, particularly for sources like OMDB where it's a full sentence (e.g., "Won 11 Oscars. 215 wins & 124 nominations total") rather than a pipe-separated list.

The previous implementation attempted to split this string, which was not appropriate. This commit ensures that:

- The `make_plot_and_tagline` function in `extras.py` now fetches the `awards_string`.
- If the string is valid (not 'N/A', not empty), it's appended as-is (after stripping whitespace) to `self.plot` under a formatted header: "[CR][CR][B]Awards:[/B][CR]".
- This displays the awards information correctly as a sentence after the main plot and tagline.

The behavior of the separate `make_awards` function and its associated `awards_id` list control remains unchanged; it will list the full awards sentence as a single item if the awards string is a sentence.