### PR TITLE
It looks like you're proposing a feature to show awards next to genre…

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -208,13 +208,13 @@ class Extras(BaseDialog):
 		self.tagline = self.meta_get('tagline') or ''
 		if self.tagline: self.plot = '[I]%s[/I][CR][CR]%s' % (self.tagline, self.plot)
 
-		awards_string = self.meta_get('extra_ratings', {}).get('Awards', '')
-		# logger("extras.py", f"make_plot_and_tagline - Fetched awards_string: {awards_string}") # Removed
-		if awards_string and awards_string != 'N/A':
-			self.plot = f"[B]Awards:[/B] {awards_string}[CR][CR]{self.plot}"
-			# logger("extras.py", f"make_plot_and_tagline - Plot after prepending awards: {self.plot}") # Removed
-		# else: # Removed logger for this path too
-			# logger("extras.py", "make_plot_and_tagline - No awards string to prepend or it was N/A") # Removed
+		# awards_string = self.meta_get('extra_ratings', {}).get('Awards', '') # Removed
+		# # logger("extras.py", f"make_plot_and_tagline - Fetched awards_string: {awards_string}") # Removed
+		# if awards_string and awards_string != 'N/A': # Removed
+			# self.plot = f"[B]Awards:[/B] {awards_string}[CR][CR]{self.plot}" # Removed
+			# # logger("extras.py", f"make_plot_and_tagline - Plot after prepending awards: {self.plot}") # Removed
+		# # else: # Removed logger for this path too
+			# # logger("extras.py", "make_plot_and_tagline - No awards string to prepend or it was N/A") # Removed
 		if not self.plot: return # Check if plot became empty after potential modifications, though unlikely here.
 		if plot_id in self.enabled_lists: self.setProperty('plot_enabled', 'true')
 
@@ -859,6 +859,11 @@ class Extras(BaseDialog):
 		self.setProperty('media_type', self.media_type), self.setProperty('title', self.title), self.setProperty('year', self.year), self.setProperty('plot', self.plot)
 		self.setProperty('genre', ', '.join(self.genre)), self.setProperty('network', ', '.join(self.network)), self.setProperty('enable_scrollbars', self.enable_scrollbars)
 		self.setProperty('display_extra_ratings', 'true' if self.display_extra_ratings else 'false')
+		awards_string = self.meta_get('extra_ratings', {}).get('Awards', 'N/A')
+		if awards_string and awards_string != 'N/A':
+			self.setProperty('awards', '[B]Awards:[/B] %s' % awards_string)
+		else:
+			self.setProperty('awards', '')
 
 	def make_status_infoline(self):
 		status_str = self.status

--- a/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
+++ b/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
@@ -148,14 +148,32 @@
                 <left>50</left>
                 <control type="group">
                     <animation effect="slide" end="0,25" time="0" condition="String.IsEqual(Window.Property(display_extra_ratings),false)">Conditional</animation>
-                    <!-- Line 1 -->
-                    <control type="label">
-                        <width max="1150">auto</width>
-                        <height>25</height>
-                        <font>font14</font> <!-- FENLIGHT_33 -->
-                        <textcolor>FFCCCCCC</textcolor>
-                        <align>center</align>
-                        <label>[I]$INFO[Window.Property(genre)][/I]</label>
+                    <!-- Line 1 - Genre and Awards -->
+                    <control type="grouplist">
+                        <left>0</left> <!-- Adjust as needed -->
+                        <top>0</top> <!-- Adjust as needed, original label had no specific top, inherited from parent group -->
+                        <width>1150</width> <!-- Max width for the grouplist -->
+                        <height>25</height> <!-- Height for the labels -->
+                        <orientation>horizontal</orientation>
+                        <align>center</align> <!-- Center the grouplist itself -->
+                        <itemgap>10</itemgap> <!-- Gap between genre and awards -->
+                        <control type="label">
+                            <width min="50" max="500">auto</width> <!-- Adjusted width, min/max values might need tuning -->
+                            <height>25</height>
+                            <font>font14</font> <!-- FENLIGHT_33 -->
+                            <textcolor>FFCCCCCC</textcolor>
+                            <align>left</align> <!-- Align text to the left within its allocated space -->
+                            <label>[I]$INFO[Window.Property(genre)][/I]</label>
+                        </control>
+                        <control type="label">
+                            <width min="50" max="600">auto</width> <!-- Adjusted width, min/max values might need tuning -->
+                            <height>25</height>
+                            <font>font14</font> <!-- FENLIGHT_33 -->
+                            <textcolor>FFCCCCCC</textcolor>
+                            <align>left</align> <!-- Align text to the left -->
+                            <label>$INFO[Window.Property(awards)]</label>
+                            <visible>!String.IsEmpty(Window.Property(awards))</visible> <!-- Only show if awards property is not empty -->
+                        </control>
                     </control>
                     <!-- Line 2 -->
                     <control type="label" id="2001">


### PR DESCRIPTION
…s in the extras window.

This change would modify the extras window to display awards next to the genres instead of prepending them to the plot.

The changes you're suggesting are:
- Modifying `plugin.video.fenlight/resources/lib/windows/extras.py`:
    - Removing awards from the plot in `make_plot_and_tagline`.
    - Adding a new window property `awards` in `set_properties`.
- Modifying `plugin.video.fenlight/resources/skins/Default/1080i/extras.xml`:
    - Adding a new label to display the `awards` property.
    - Adjusting the layout to display genres and awards side-by-side.