### PR TITLE
Fix: Address awards display issues in extras window

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -861,7 +861,7 @@ class Extras(BaseDialog):
 		self.setProperty('display_extra_ratings', 'true' if self.display_extra_ratings else 'false')
 		awards_string = self.meta_get('extra_ratings', {}).get('Awards', 'N/A')
 		if awards_string and awards_string != 'N/A':
-			self.setProperty('awards', '[B]Awards:[/B] %s' % awards_string)
+			self.setProperty('awards', awards_string)
 		else:
 			self.setProperty('awards', '')
 

--- a/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
+++ b/plugin.video.fenlight/resources/skins/Default/1080i/extras.xml
@@ -158,7 +158,7 @@
                         <align>center</align> <!-- Center the grouplist itself -->
                         <itemgap>10</itemgap> <!-- Gap between genre and awards -->
                         <control type="label">
-                            <width min="50" max="500">auto</width> <!-- Adjusted width, min/max values might need tuning -->
+                            <width min="50" max="450">auto</width> <!-- Adjusted width, min/max values might need tuning -->
                             <height>25</height>
                             <font>font14</font> <!-- FENLIGHT_33 -->
                             <textcolor>FFCCCCCC</textcolor>
@@ -166,7 +166,7 @@
                             <label>[I]$INFO[Window.Property(genre)][/I]</label>
                         </control>
                         <control type="label">
-                            <width min="50" max="600">auto</width> <!-- Adjusted width, min/max values might need tuning -->
+                            <width min="50" max="690">auto</width> <!-- Adjusted width, min/max values might need tuning -->
                             <height>25</height>
                             <font>font14</font> <!-- FENLIGHT_33 -->
                             <textcolor>FFCCCCCC</textcolor>


### PR DESCRIPTION
This change incorporates your feedback on the awards display:
- Removes the "Awards:" prefix from the awards string.
- Adjusts label widths in the skin file to prevent cropping of the awards text.

Changes made:
- Modified `plugin.video.fenlight/resources/lib/windows/extras.py`:
    - Removed "[B]Awards:[/B]" prefix when setting the `awards` property.
- Modified `plugin.video.fenlight/resources/skins/Default/1080i/extras.xml`:
    - Adjusted `max` width for genre label to 450.
    - Adjusted `max` width for awards label to 690 to utilize available space in the grouplist and prevent cropping.