### PR TITLE
Fix: Correct import for RottenTomatoesClient

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -11,7 +11,14 @@ import os
 lib_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if lib_dir not in sys.path:
     sys.path.insert(0, lib_dir)
-from script.module.rottentomatoesclient.rotten_tomatoes_client.client import RottenTomatoesClient
+
+# rotten_tomatoes_lib_dir is .../resources/lib/script.module.rottentomatoesclient/
+rotten_tomatoes_lib_dir = os.path.join(lib_dir, 'script.module.rottentomatoesclient')
+if rotten_tomatoes_lib_dir not in sys.path:
+    sys.path.insert(0, rotten_tomatoes_lib_dir)
+
+# Now we can import rotten_tomatoes_client directly
+from rotten_tomatoes_client.client import RottenTomatoesClient
 from modules import kodi_utils, settings, watched_status
 from modules.settings import get_setting
 from modules.kodi_utils import execute_builtin, get_property


### PR DESCRIPTION
The addon was attempting to import RottenTomatoesClient using a path like `script.module.rottentomatoesclient.rotten_tomatoes_client.client`, which failed because Python interpreted `script.module.rottentomatoesclient` as a series of nested modules starting from a top-level `script` package, rather than recognizing `script.module.rottentomatoesclient` as a single directory name.

This commit fixes the import error by:
1. Adding the `plugin.video.fenlight/resources/lib/script.module.rottentomatoesclient/` directory directly to `sys.path` within `plugin.video.fenlight/resources/lib/windows/extras.py`.
2. Changing the import statement in the same file to `from rotten_tomatoes_client.client import RottenTomatoesClient`.

This ensures that the `rottentomatoesclient` module, which is bundled with the addon, is correctly located and imported, resolving the "No module named 'script'" error and subsequent 'NoneType' errors during window creation.