### PR TITLE
Fix: Correct Rotten Tomatoes client search call

### DIFF
--- a/plugin.video.fenlight/resources/lib/windows/extras.py
+++ b/plugin.video.fenlight/resources/lib/windows/extras.py
@@ -629,7 +629,11 @@ class Extras(BaseDialog):
 			# Also instantiating client as requested, though not strictly needed for static methods.
 			_ = RottenTomatoesClient() # Instantiation as requested. Result not used if methods are static.
 
-			search_results = RottenTomatoesClient.search(title=media_title, year=media_year if media_year and media_year != '0' else None)
+			search_term = media_title
+			if media_year and media_year != '0':
+				search_term += f" ({media_year})" # Match the logging format
+			logger('fenlight.extras.show_trailers', f'Constructed search term for Rotten Tomatoes: {search_term}')
+			search_results = RottenTomatoesClient.search(term=search_term, limit=3)
 
 			if search_results and isinstance(search_results, list) and len(search_results) > 0:
 				# Assuming the first result is the most relevant one.


### PR DESCRIPTION
The Rotten Tomatoes client's `search` method was being called with an unexpected `title` keyword argument. This commit updates the call in `extras.py` to use the correct `term` argument, constructing it from the media title and year.

The `limit` parameter has also been added to the search call.

This resolves the `TypeError: search() got an unexpected keyword argument 'title'` error and allows the Rotten Tomatoes trailer search functionality to work as intended.